### PR TITLE
Show task on add, delete, done, undone

### DIFF
--- a/cmd_add.go
+++ b/cmd_add.go
@@ -19,7 +19,9 @@ func makeCmdAdd(filename string) *commander.Command {
 			return err
 		}
 		defer w.Close()
-		_, err = fmt.Fprintf(w, " %s\n", strings.Join(args, " "))
+		task := strings.Join(args, " ")
+		_, err = fmt.Fprintln(w, task)
+		fmt.Printf("Task added: %s\n", task)
 		return err
 	}
 

--- a/cmd_delete.go
+++ b/cmd_delete.go
@@ -34,8 +34,7 @@ func makeCmdDelete(filename string) *commander.Command {
 			return err
 		}
 		br := bufio.NewReader(f)
-		n := 1
-		for {
+		for n := 1; ; n++ {
 			b, _, err := br.ReadLine()
 			if err != nil {
 				if err != io.EOF {
@@ -49,13 +48,14 @@ func makeCmdDelete(filename string) *commander.Command {
 					match = true
 				}
 			}
-			if !match {
+			if match {
+				fmt.Printf("Task deleted: %s\n", string(b))
+			} else {
 				_, err = fmt.Fprintf(w, "%s\n", string(b))
 				if err != nil {
 					return err
 				}
 			}
-			n++
 		}
 		f.Close()
 		w.Close()

--- a/cmd_done.go
+++ b/cmd_done.go
@@ -35,8 +35,7 @@ func makeCmdDone(filename string) *commander.Command {
 			return err
 		}
 		br := bufio.NewReader(f)
-		n := 1
-		for {
+		for n := 1; ; n++ {
 			b, _, err := br.ReadLine()
 			if err != nil {
 				if err != io.EOF {
@@ -56,13 +55,13 @@ func makeCmdDone(filename string) *commander.Command {
 				if err != nil {
 					return err
 				}
+				fmt.Printf("Task done: %s\n", line)
 			} else {
 				_, err = fmt.Fprintf(w, "%s\n", line)
 				if err != nil {
 					return err
 				}
 			}
-			n++
 		}
 		f.Close()
 		w.Close()

--- a/cmd_undone.go
+++ b/cmd_undone.go
@@ -35,8 +35,7 @@ func makeCmdUndone(filename string) *commander.Command {
 			return err
 		}
 		br := bufio.NewReader(f)
-		n := 1
-		for {
+		for n := 1; ; n++ {
 			b, _, err := br.ReadLine()
 			if err != nil {
 				if err != io.EOF {
@@ -56,13 +55,13 @@ func makeCmdUndone(filename string) *commander.Command {
 				if err != nil {
 					return err
 				}
+				fmt.Printf("Task undone: %s\n", line[1:])
 			} else {
 				_, err = fmt.Fprintf(w, "%s\n", line)
 				if err != nil {
 					return err
 				}
 			}
-			n++
 		}
 		f.Close()
 		w.Close()


### PR DESCRIPTION
## Description

When I {add,delete,done,undone} task, I can't know what task is {added,deleted,done,undone}.

This change enables CLI to give a feedback to the user what task is added, deleted, done and undone.

## Behavior

```console
$ todo add test
Task added: test

$ todo list
☐ 001: test

$ todo done 1
Task done: test

$ todo list
☑ 001: test

$ todo undone 1
Task undone: test

$ todo list
☐ 001: test

$ todo delete 1
Task deleted: test

$ todo list

```