### PR TITLE
Fix on updating completed tasks.

### DIFF
--- a/cmd_update.go
+++ b/cmd_update.go
@@ -57,7 +57,7 @@ func makeCmdUpdate(filename string) *commander.Command {
 				if err != nil {
 					return err
 				}
-				fmt.Printf("Task %d updated with message: %s\n", id, task)
+				fmt.Printf("Task %d updated with message: %s\n", id, task[1:])
 			} else {
 				_, err = fmt.Fprintf(w, "%s\n", originalTask)
 				if err != nil {

--- a/cmd_update.go
+++ b/cmd_update.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"bufio"
-	"strconv"
 	"fmt"
-	"os"
 	"io"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/gonuts/commander"
@@ -46,14 +46,20 @@ func makeCmdUpdate(filename string) *commander.Command {
 			if id == n {
 				match = true
 			}
+
+			originalTask := string(b)
 			if match {
+				hasCompleted := strings.HasPrefix(originalTask, "-")
+				if hasCompleted {
+					task = "-" + task
+				}
 				_, err = fmt.Fprintf(w, "%s\n", task)
 				if err != nil {
 					return err
 				}
 				fmt.Printf("Task %d updated with message: %s\n", id, task)
 			} else {
-				_, err = fmt.Fprintf(w, "%s\n", string(b))
+				_, err = fmt.Fprintf(w, "%s\n", originalTask)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
The existing code removes the completed indicator (which is '-') upon updating a completed task. This PR introduces a new change that checks if the task has already been completed. If so, we're writing a '-' along with the new task string.